### PR TITLE
adding esp32-s3-zero-mini support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,8 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+bkp/
+*bkp*
+CLAUDE.md
+.claude/

--- a/README.md
+++ b/README.md
@@ -1,119 +1,384 @@
-# ESP32 Wake-on-LAN (WoL) Controller with Telnet Server
+# Wake-on-LAN Controller for Any Device
 
-This project provides a solution to remotely power on and manage a non-smart device using an ESP32. The device listens for WoL magic packets and includes a Telnet server for remote management. It can simulate pressing the power button of an external device and provides status monitoring.
+Multi-platform Wake-on-LAN (WoL) solution to remotely power on and manage non-smart devices. Supports ESP32 variants with Telnet server and Raspberry Pi Pico W with CircuitPython implementations.
 
-## Features
+## Supported Hardware Platforms
 
-- **Wake-on-LAN Listener**: Listens for WoL magic packets on UDP port 9
-- **Power Button Simulation**: Simulates pressing the power button via relay control
-- **Device Status Monitoring**: Detects if the external device is ON/OFF via status pin
-- **Telnet Server**: Provides remote command interface on port 23
-- **UART Console**: Direct serial access to connected device via hardware UART pins
-- **WiFi Management**: Automatic reconnection and system reboot on persistent failures
-- **Visual Feedback**: Multiple LEDs for status indication (onboard + RGB LEDs)
+| Platform | Language | Status | Key Features |
+|----------|----------|--------|--------------|
+| **ESP32 Dev Module** | Arduino C++ | Production | Telnet + UART console, RGB LEDs, FreeRTOS multitasking |
+| **ESP32-S3-Zero-Mini** | Arduino C++ | Stable (v1.0.8) | Compact, NeoPixel RGB, double-press poweroff, improved console |
+| **Raspberry Pi Pico W** | CircuitPython | Alternative | External config file, async variants, lower cost |
 
-## Hardware Requirements
+## Core Features
 
-- ESP32 Dev Module
-- NPN Transistor (e.g., 2N2222 or BC547)
-- Resistors:
-  - 1kΩ resistor (for transistor base)
-  - 10kΩ resistor (for power device state)
-  - 220Ω resistors for LEDs
-- LEDs:
-  - Green LED (GP21)
-  - Red LED (GP22)
-  - Blue LED (GP23)
-- 2N2222 Transistor
-- External Device with power button
+- **Wake-on-LAN Listener**: Monitors UDP port 9 for magic packets
+- **Power Button Simulation**: Relay/transistor-based power button control
+- **Device Status Monitoring**: Detects external device ON/OFF state via GPIO input
+- **Telnet Server**: Remote command interface on port 23 (ESP32 platforms)
+- **UART Console Pass-through**: Direct serial access to connected device
+- **WiFi Auto-reconnection**: Automatic recovery with system reboot on persistent failures
+- **Visual Feedback**: LED status indicators (RGB or NeoPixel)
+
+---
+
+## ESP32 Dev Module (Primary Implementation)
+
+### Hardware Requirements
+- ESP32 Dev Module (30-pin)
+- NPN Transistor (2N2222 or BC547)
+- Resistors: 1kΩ (transistor base), 10kΩ (status pull-down), 220Ω × 3 (LEDs)
+- LEDs: Separate Red, Green, Blue (5mm standard)
 - Jumper wires
 
-## Wiring Diagram
-
-ESP32 Dev Module
+### GPIO Configuration
 ```
+GPIO18  - Transistor control (power button simulation)
+GPIO19  - Device status input (3.3V when device ON)
+GPIO21  - Green LED
+GPIO22  - Red LED
+GPIO23  - Blue LED
+GPIO2   - Onboard LED (WiFi connection indicator)
+GPIO16  - UART RX (to device TX)
+GPIO17  - UART TX (to device RX)
+```
+
+### Wiring Diagram
+```
+ESP32 Dev Module
 +3.3V ----------------------------------- 3V3
 GND ------------------------------------- GND
 
 GPIO18 --------------------------------[2N2222 Transistor]
-GPIO19 -------------[10Ω]--------------[Device Status Input (3.3V when ON)]
+GPIO19 -------------[10kΩ]-------------[Device Status Input (3.3V when ON)]
 
-GPIO21 ---------------------------------[Green LED]
-GPIO22 ---------------------------------[Red LED]
-GPIO23 ---------------------------------[Blue LED]
-[Common Ground for LEDs] ---------------[220Ω]---- GND
+GPIO21 ---------[220Ω]----------------[Green LED]--[GND]
+GPIO22 ---------[220Ω]----------------[Red LED]----[GND]
+GPIO23 ---------[220Ω]----------------[Blue LED]---[GND]
 
-GPIO16 (UART RX) -----------------------[To Device TX]
-GPIO17 (UART TX) -----------------------[To Device RX]
+GPIO16 (UART RX) ----------------------[To Device TX]
+GPIO17 (UART TX) ----------------------[To Device RX]
 ```
 
-2N2222 Transistor Wiring
+### 2N2222 Transistor Wiring
 ```
-                                        |---[Collector (C)]---[Wire 1 of Power Button / 3.3v / Powered side ]
-   GPIO18 ------[1kΩ]------[(2N2222)]-----|---[Base (B)]
-                                        |---[Emitter (E)]-----[Wire 2 of Power Button / GND side)
+                                    |---[Collector (C)]---[Power Button Wire 1 / 3.3V side]
+GPIO18 ------[1kΩ]------[(2N2222)]-----|---[Base (B)]
+                                    |---[Emitter (E)]-----[Power Button Wire 2 / GND side]
 ```
 
-## Telnet Commands
+### Configuration
+Edit `esp32_dev_module/TelnetCommandServer.ino`:
+```cpp
+#define WIFI_SSID "YOUR_SSID"
+#define WIFI_PASS "YOUR_PASSWORD"
+uint8_t targetMAC[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05};  // Your device MAC
+```
 
-Connect to the ESP32 via Telnet (port 23) to access these commands:
-- `status` - Show system status (WiFi, IP, MAC, device state)
-- `reset` - Restart the ESP32
-- `console` - Enter UART console mode with connected device
-- `poweron` - Turn device on (if off)
-- `poweroff` - Turn device off (if on)
-- `poweron -c` - Turn device on and enter console mode
-- `poweroff -f` - Force power off (long press)
-- `exit` - Disconnect from Telnet session
+---
+
+## ESP32-S3-Zero-Mini (Compact Alternative)
+
+### Improvements Over Dev Module
+- **Smaller form factor** - Compact S3 board with USB-C
+- **Single NeoPixel RGB LED** - Replaces 3 separate LEDs, color-coded status
+- **Double-press poweroff** - More reliable power-down sequence (2× 500ms pulses)
+- **Enhanced console escape** - Ctrl+Q only (v1.0.8), all other chars pass through
+- **ESP-IDF 5.x compatible** - Updated socket handling and watchdog management
+- **Monitoring MAC display** - Shows target MAC in status command
+
+### Hardware Requirements
+- ESP32-S3-Zero-Mini board
+- NPN Transistor (2N2222 or BC547)
+- Resistors: 1kΩ (transistor base), 10kΩ (status pull-down)
+- **No separate LEDs required** (uses onboard NeoPixel)
+- Jumper wires
+
+### GPIO Configuration
+```
+GPIO3   - Power control (transistor base)
+GPIO2   - Device status input (3.3V when device ON)
+GPIO21  - NeoPixel RGB LED (WS2812B)
+GPIO7   - UART TX (to device RX)
+GPIO8   - UART RX (from device TX)
+```
+
+### NeoPixel Color Coding
+- **Blue**: WiFi status checking
+- **Green**: Power button activation
+- **Red**: Error / WiFi connection failure
+
+### Wiring Diagram
+```
+ESP32-S3-Zero-Mini
++3.3V ----------------------------------- 3V3
+GND ------------------------------------- GND
+
+GPIO3  --------------------------------[2N2222 Transistor]
+GPIO2  -------------[10kΩ]-------------[Device Status Input (3.3V when ON)]
+
+GPIO21 --------------------------------[NeoPixel RGB LED (built-in or external WS2812B)]
+
+GPIO7 (UART TX) -----------------------[To Device RX]
+GPIO8 (UART RX) -----------------------[From Device TX]
+```
+
+### Configuration
+Edit `ESP32-S3-Zero-Mini/ESP32-S3-Zero-Mini.ino`:
+```cpp
+#define WIFI_SSID "YOUR_SSID"
+#define WIFI_PASS "YOUR_PASSWORD"
+uint8_t targetMAC[] = {0x28, 0xc6, 0x8e, 0xd5, 0xc8, 0xdc};  // Your device MAC
+#define NEOPIXEL_BRIGHTNESS 60  // Adjust 0-255
+```
+
+### Version History (ESP32-S3-Zero-Mini)
+- **v1.0.8**: Reverted to simple Ctrl+Q escape only, all other chars pass through
+- **v1.0.7**: Fixed console escape (Ctrl+], Ctrl+D exit cleanly; Ctrl+C passes through)
+- **v1.0.6**: Added multiple console exit methods (Ctrl+Q, Ctrl+D, ~~~)
+- **v1.0.5**: Fixed UART pins (RX=7, TX=8), poweroff now double press
+- **v1.0.4**: Fixed NeoPixel colors (WiFi=BLUE, Power=GREEN, Error=RED)
+- **v1.0.3**: Added monitoring MAC to status, changed MAC format to colons
+- **v1.0.2**: Removed manual watchdog init (Arduino core auto-manages)
+- **v1.0.1**: Fixed ESP-IDF 5.x compatibility (esp_task_wdt_init, flush, accept)
+- **v1.0.0**: Initial ESP32-S3 Zero Mini adaptation with NeoPixel support
+
+---
+
+## Raspberry Pi Pico W (CircuitPython Alternatives)
+
+### Available Variants
+1. **code_v1.py** - Simple synchronous implementation
+2. **code_v2_async.py** - Asynchronous with better CPU efficiency
+3. **code_v2_telnet-ro.py** - Async with Telnet server + UART console (read-only)
+
+### Hardware Requirements
+- Raspberry Pi Pico W
+- NPN Transistor (2N2222 or BC547)
+- Resistors: 1kΩ (transistor base), 10kΩ (status pull-down), 220Ω × 3 (LEDs)
+- LEDs: Separate Red, Green, Blue
+- Jumper wires
+
+### GPIO Configuration
+```
+GP13  - Transistor control
+GP14  - Device status input
+GP5   - Red LED
+GP6   - Green LED
+GP7   - Blue LED
+GP0   - UART TX (telnet-ro variant only)
+GP1   - UART RX (telnet-ro variant only)
+```
+
+### Configuration
+Edit `rpi_pico_w/settings.ini`:
+```ini
+TARGET_MAC = 00:01:02:03:04:05
+WIFI_SSID = YOUR_SSID
+WIFI_PASSWORD = YOUR_PASSWORD
+WIFI_FREQ_CHECK = 10
+WIFI_FAILED_ATTEMPTS = 10
+STATIC_IP =                    # Leave empty for DHCP
+STATIC_SUBNET_MASK =
+STATIC_GATEWAY =
+STATIC_DNS =
+```
+
+---
+
+## Telnet Commands (ESP32 Platforms Only)
+
+Connect via `telnet <device-ip> 23`:
+
+| Command | Description |
+|---------|-------------|
+| `status` | Show WiFi SSID, IP, MAC, device state, monitoring MAC |
+| `reset` | Restart ESP32 |
+| `console` | Enter UART console mode (Ctrl+Q to exit) |
+| `poweron` | Turn device on (500ms press) |
+| `poweroff` | Turn device off (500ms press, S3: double-press) |
+| `poweron -c` | Power on and enter console mode |
+| `poweroff -f` | Force power off (5000ms long press) |
+| `exit` | Disconnect from Telnet session |
+
+---
 
 ## UART Console Access
 
-The ESP32 provides direct UART pass-through to the connected device:
+### ESP32 Dev Module
 - **UART Pins**: GPIO16 (RX), GPIO17 (TX)
 - **Baud Rate**: 115200
-- **Access Methods**:
-  1. Via Telnet `console` command
-  2. Direct serial connection to ESP32's UART pins
-- **Exit Console**: Press Ctrl+Q (ASCII 17)
+- **Exit**: Ctrl+Q
+
+### ESP32-S3-Zero-Mini
+- **UART Pins**: GPIO8 (RX), GPIO7 (TX)
+- **Baud Rate**: 115200
+- **Exit**: Ctrl+Q (v1.0.8: passes all other chars including Ctrl+C)
+
+### Raspberry Pi Pico W (telnet-ro variant)
+- **UART Pins**: GP0 (TX), GP1 (RX)
+- **Baud Rate**: 115200
+- **Access**: Telnet read-only forwarding
+
+---
 
 ## Setup Instructions
 
-1. Update the code with your WiFi credentials:
+### 1. Choose Your Platform
+- **ESP32 Dev Module** - Most features, full Telnet + UART, standard form factor
+- **ESP32-S3-Zero-Mini** - Compact, refined features, single NeoPixel LED
+- **Raspberry Pi Pico W** - External configuration, CircuitPython, budget option
+
+### 2. Configure WiFi and Target MAC
+- **ESP32 platforms**: Edit `#define` statements in .ino file
+- **Pico W**: Edit `settings.ini` file
+
+### 3. Upload Code
+- **ESP32**: Use Arduino IDE or PlatformIO
+- **Pico W**: Copy .py files to CIRCUITPY drive
+
+### 4. Wire Hardware
+- Follow platform-specific wiring diagram above
+- Verify transistor pinout (flat side = BCE for 2N2222)
+- Use 10kΩ pull-down resistor on status input
+
+### 5. Power On and Test
+- **WiFi Connection**: Onboard LED blinks (ESP32) or status LEDs indicate connection
+- **Wake Device**: Send WoL magic packet to UDP port 9 OR use Telnet `poweron`
+- **Console Access**: Use Telnet `console` command (ESP32 only)
+
+---
+
+## LED Status Indicators
+
+### ESP32 Dev Module
+- **Blue LED**: WiFi status checking
+- **Red/Green LEDs**: Device power state
+- **Onboard LED (GPIO2)**: Blinks during WiFi connection
+
+### ESP32-S3-Zero-Mini (NeoPixel)
+- **Blue**: WiFi status checking
+- **Green**: Power button activation
+- **Red**: Error / WiFi connection failure
+
+### Raspberry Pi Pico W
+- **Blue/Green LEDs**: WiFi and device status
+- **Red LED**: Data transmission (telnet-ro variant)
+
+---
+
+## Architecture Notes
+
+### Multi-threading (ESP32 Platforms)
+Both ESP32 implementations use FreeRTOS tasks for concurrent operations:
+- **Task 1 (Core 0)**: WiFi connection monitoring (15-second intervals)
+- **Task 2 (Core 0)**: WoL packet listener (10ms polling)
+- **Task 3 (Core 1)**: Telnet server handler
+
+### WiFi Recovery Strategy
+- **ESP32**: 10 reconnection attempts, then system restart
+- **Pico W**: 10 failed attempts with exponential backoff, then reboot
+
+### Watchdog Timer
+- **ESP32 Dev Module**: Manual 30-second watchdog with reset during console mode
+- **ESP32-S3**: Auto-managed by Arduino core (ESP-IDF 5.x)
+- **Pico W**: No hardware watchdog (relies on software reset)
+
+---
+
+## 3D Printable Case
+
+**Available for ESP32 Dev Module:**
+- File: `esp32_dev_module/3d_print/ESP32 DevKit Case v1.stl`
+- Enclosure for complete assembled hardware
+
+---
+
+## Project Structure
+
 ```
-   #define WIFI_SSID "YOUR_SSID"
-   #define WIFI_PASS "YOUR_PASSWORD"
+wakeonlan-for-any-device/
+├── esp32_dev_module/
+│   ├── TelnetCommandServer.ino         # ESP32 DevKit implementation
+│   └── 3d_print/
+│       └── ESP32 DevKit Case v1.stl
+├── ESP32-S3-Zero-Mini/
+│   └── ESP32-S3-Zero-Mini.ino          # ESP32-S3 compact variant (v1.0.8)
+├── rpi_pico_w/
+│   ├── code_v1.py                      # Synchronous Pico W
+│   ├── code_v2_async.py                # Async Pico W
+│   ├── code_v2_telnet-ro.py            # Async with Telnet + UART
+│   └── settings.ini                    # External configuration
+├── README.md
+├── LICENSE
+└── CLAUDE.md
 ```
 
-Configure the target MAC address:
-```
-uint8_t targetMAC[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05};
-```
-
-2. Upload the code to your ESP32 using Arduino IDE or PlatformIO
-
-3. Connect the hardware as per wiring diagram
-
-4. Power on the system - the onboard LED will blink when WiFi connects
-- Operation When powered:
-- Blue LED indicates WiFi status
-- Onboard LED (GP2) blinks during WiFi connection
-- Red/Green LEDs show device power state
-
-5. To wake device:
-- Send WoL magic packet to UDP port 9
-- OR use Telnet poweron command
-- For direct console access:
-- Connect to device UART via GPIO16/17
-- OR use Telnet console command
+---
 
 ## License
-This project is licensed under the GNU GENERAL PUBLIC LICENSE. See the LICENSE file for details.
 
-## Acknowledgments
-Inspired by Wake-on-LAN functionality and ESP32 capabilities
+This project is licensed under the **GNU General Public License v3.0**. See LICENSE file for details.
+
+---
 
 ## Contributing
-Contributions are welcome! Please open an issue or submit a pull request for any improvements or bug fixes.
+
+Contributions welcome! Please:
+1. Fork the repository
+2. Create a feature branch
+3. Test on target hardware
+4. Submit pull request with detailed description
+
+---
+
+## Acknowledgments
+
+- Inspired by Wake-on-LAN protocol (AMD Magic Packet)
+- Built on ESP32/ESP-IDF and CircuitPython ecosystems
+- Community feedback for console escape improvements
+
+---
 
 ## Contact
-For questions or feedback, please open an issue on the GitHub repository.
+
+For questions, issues, or feature requests:
+- Open an issue on the GitHub repository
+- Repository: https://github.com/geekinsanemx/wakeonlan-for-any-device
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+**WiFi won't connect:**
+- Verify SSID/password in code or settings.ini
+- Check 2.4GHz network (ESP32/Pico W don't support 5GHz)
+- Monitor serial console at 115200 baud for connection logs
+
+**WoL magic packet not working:**
+- Confirm target MAC address matches device exactly
+- Verify UDP port 9 not blocked by firewall
+- Check device supports Wake-on-LAN (BIOS/UEFI setting)
+- Test with `wakeonlan` CLI tool: `wakeonlan -i <broadcast-ip> <MAC>`
+
+**Telnet connection refused:**
+- Ensure ESP32 WiFi connected (check serial console)
+- Verify port 23 not blocked by firewall
+- Test with: `telnet <esp32-ip> 23`
+
+**Console mode garbled text (ESP32-S3):**
+- Verify UART baud rate matches device (default: 115200)
+- Check TX/RX not swapped (GPIO7=TX, GPIO8=RX)
+- Ensure common ground between ESP32-S3 and target device
+
+**Power button simulation not working:**
+- Verify transistor wiring (Base ← GPIO via 1kΩ, Collector ↔ Button, Emitter → GND)
+- Test transistor with multimeter (should conduct when GPIO HIGH)
+- Check power button wires correctly identified (may need to swap)
+
+**Status detection always shows OFF:**
+- Verify 10kΩ pull-down resistor installed on status GPIO
+- Check target device provides 3.3V when ON (use multimeter)
+- Ensure GPIO configured as INPUT (code default)


### PR DESCRIPTION
  - Multi-platform documentation (ESP32 DevKit + ESP32-S3-Zero-Mini + Pico W)
  - Platform comparison table
  - Complete ESP32-S3-Zero-Mini documentation with v1.0.8 changelog
  - Separate GPIO configurations and wiring diagrams for each platform
  - NeoPixel color coding for S3 variant
  - Architecture notes (FreeRTOS, WiFi recovery, watchdog)
  - Troubleshooting section
  - Project structure overview
  - 3D printable case reference

  ESP32-S3-Zero-Mini improvements documented:
  - Compact form factor with USB-C
  - Single NeoPixel RGB vs 3 separate LEDs
  - Double-press poweroff mechanism
  - Enhanced Ctrl+Q console escape (v1.0.8)
  - ESP-IDF 5.x compatibility
  - Monitoring MAC display in status
